### PR TITLE
New version 3.9.5

### DIFF
--- a/wcstools.rb
+++ b/wcstools.rb
@@ -1,23 +1,15 @@
 class Wcstools < Formula
   desc "Tools for using World Coordinate Systems (WCS) in astronomical images"
   homepage "http://tdc-www.harvard.edu/wcstools/"
-  url "http://tdc-www.harvard.edu/software/wcstools/wcstools-3.9.2.tar.gz"
-  sha256 "481fe357cf755426fb8e25f4f890e827cce5de657a4e5044d4e31ce27bef1c8b"
-
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "e62507e22777515b183a1e9e311427033ac97d2db08b0f1c09937907f95bf4f4" => :el_capitan
-    sha256 "70caab977d57e6b999a4242d381d1c1619b7ef2bde5da1317bc5f8672d322651" => :yosemite
-    sha256 "f731758ecfb3fdf169be64b1db0c05ff16bb727aed01b76a6bdc20d2cb523890" => :mavericks
-  end
+  url "ftp://cfa-ftp.harvard.edu/pub/gsc/WCSTools/wcstools-3.9.5.tar.gz"
+  sha256 "b2f9be55fdec29f0c640028a9986771bfd6ab3d2f633953e4c7cc3b410e5fe9c"
 
   def install
     system "make", "-f", "Makefile.osx", "all"
-
     prefix.install "bin"
   end
 
   test do
-    system "imhead 2>&1 | grep -q 'IMHEAD'"
+    system "#{bin}/imhead 2>&1 | grep -q 'IMHEAD'"
   end
 end


### PR DESCRIPTION
Old version was 3.9.2 which is no longer available (broken Formula)

### Have you:

- [X] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [X] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [X] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [X] Built your formula locally prior to submission with `brew install <formula>`?

### New formula:

We will no longer accept new formula in homebrew-science, as this tap is being phased out.
Please consider submitting your formulae to https://github.com/Homebrew/homebrew-core or host it in your own tap (https://docs.brew.sh/How-to-Create-and-Maintain-a-Tap.html).

### Updates to existing formula: have you

- [n/a] Removed the `revision` line, if any, when bumping the version number?
- [n/a] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [X] Not altered the `bottle` section?
- [X] Checked that the tests still pass?
